### PR TITLE
FPS/SpecList/Save/Load

### DIFF
--- a/codjumper/_cj_functions.gsc
+++ b/codjumper/_cj_functions.gsc
@@ -2,10 +2,8 @@
 
 savePos(i)
 {		
-	if (isDefined(self.cj["custom_save"]) && self.cj["custom_save"]==0)
+	if ((isDefined(self.cj["custom_save"]) && self.cj["custom_save"]==0) ||  !isDefined(self.cj["custom_save"]))
 	{
-		if (self.cj["saves"] == 0)
-			self.cj["saves"]  = 1;
 		self.cj["saves"]++; //Ignore i so we don't need to modify too much and just use a local variable here.
 		i=self.cj["saves"];
 	} else {

--- a/hud/fps.gsc
+++ b/hud/fps.gsc
@@ -1,13 +1,16 @@
 #include addons\_spectator;
 #include hud\common;
+
 mainLoop()
 {
 	self endon( "disconnect" );
 	lastfps =  self getMaxFPS();
-	self.fps = addTextHud(self, 0, -187, 1 , "center", "middle", "center","middle","default", 2.5);
-	self.fps.hidewheninmenu = 1;
-	self.fps setValue(lastfps);
+	self.ebc["fps"] = addTextHud(self, 0, -187, 1 , "center", "middle", "center","middle","default", 2.5);
+	self.ebc["fps"].hidewheninmenu = 1;
+	self.ebc["fps"] setValue(lastfps);
 	
+	
+	//codjumper\_cj_utility::execClientCommand("setu cow_maxfps 125");
 	
 	self.ebc["fpsLine"] = newClientHudElem( self );
 	self.ebc["fpsLine"].x = -2;
@@ -22,12 +25,23 @@ mainLoop()
 	self.ebc["fpsLine"].alpha =1;
 	self.ebc["fpsLine"].archived = false;
 
-		
+	self.ebc["modified_fps_msg"] = addTextHud(self, 0, -160, 1 , "center", "middle", "center","middle","default", 1.4);
+	self.ebc["modified_fps_msg"].hidewheninmenu = 1;
+	self.ebc["modified_fps_msg"] setText("Modified com_maxfps variable found.\r\nUsing counted fps (not as accurate)");
+	self.ebc["modified_fps_msg"].alpha = 0;
 	while(1)
 	{
 		player = getActiveClient();
 		last_fps = player getMaxFPS();
-		self.fps setValue(last_fps);
+		self.ebc["fps"] setValue(last_fps);
+		
+		if (isDefined(player.ebc["maxfps_modified"]))
+		{
+			if (player.ebc["maxfps_modified"]==1)
+				self.ebc["modified_fps_msg"].alpha = 1;
+			else 
+				self.ebc["modified_fps_msg"].alpha = 0;
+		}
 		wait 0.05;
 	}
 }
@@ -35,5 +49,41 @@ mainLoop()
 getMaxFPS()
 {
 	self endon("disconnect");	
-	return int(min(1000,int(self [[level.getUserInfo]]("com_maxfps"))));
+
+	fps = int(min(1000,int(self [[level.getUserInfo]]("com_maxfps"))));
+	if (fps==0)
+	{
+		fps = getNearestFPS(self getCountedFPS());
+		self.ebc["maxfps_modified"] = true;
+	} else {
+		self.ebc["maxfps_modified"] = false;
+	}
+
+	return fps;
+}
+
+getNearestFPS(countedFPS)
+{
+	rval = 0;
+	if (countedFPS > 100 && countedFPS<=200)
+	{
+		rval = 125;
+	}
+	else if (countedFPS > 200 && countedFPS<=300)
+	{
+		rval = 250;
+	}
+	else if (countedFPS > 300 && countedFPS<=450)
+	{
+		rval = 333;
+	} 
+	else if (countedFPS > 450 && countedFPS<=600)
+	{
+		rval = 500;
+	} 
+	else if (countedFPS > 600)
+	{
+		rval = 1000;
+	}
+	return rval;
 }

--- a/hud/speclist.gsc
+++ b/hud/speclist.gsc
@@ -2,7 +2,7 @@
 mainLoop()
 {
 	self endon( "disconnect" );
-	self.specList = addTextHud(self, -5, -187, 1 , "right", "middle", "right","middle","normal", 1.4);
+	self.specList = addTextHud(self, -5, -187, 1 , "right", "middle", "right","middle","default", 1.4);
 	self.specList.hidewheninmenu = 1;
 	self.specList.label = &"Spectators&&1";
 	player = self;


### PR DESCRIPTION
FPS now detects modified com_maxfps variable and switches over to using counted fps.

Speclist font changed to default from normal (normal isn't a font)
Saving and loading bug that caused the first save and load to load save position 0.